### PR TITLE
Add .flushExpired() and .flushUnused() to help clear out cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,20 @@ Flush all keys and values.
 
 * callback: type: function
 
+## .flushExpired([cb])
+
+Flush all expired keys and values.
+
+* callback: type: function
+
+## .flushUnused(timeout, [cb])
+
+Flush keys and values that haven't been used in the last N seconds
+(as specified by the timeout).
+
+* timeout: type: int
+* callback: type: function
+
 # Using Background Refresh
 
 With a typical cache setup, you're left to find the perfect compromise between having a long expiration so that users don't have to suffer through the worst case load time, and a short expiration so data doesn't get stale. `cache-service-cache-module` eliminates the need to worry about users suffering through the longest wait time by automatically refreshing keys for you. Here's how it works:

--- a/cacheModule.js
+++ b/cacheModule.js
@@ -218,11 +218,11 @@ function cacheModule(config){
    */
   self.flushUnused = function(timeout, cb){
     log(false, '.flushUnused() called');
-    var now = Date.now() - (timeout * 1000);
+    var nowMinusTimeout = Date.now() - (timeout * 1000);
     for(var key in cache.lastUsed){
       if(cache.db.hasOwnProperty(key)){
         var lastUsed = cache.lastUsed[key];
-        if(lastUsed <= now){
+        if(lastUsed <= nowMinusTimeout){
           expire(key);
         }
       }

--- a/cacheModule.js
+++ b/cacheModule.js
@@ -31,6 +31,7 @@ function cacheModule(config){
   var cache = {
     db: {},
     expirations: {},
+    lastUsed: {},
     refreshKeys: {}
   };
   var storageKey;
@@ -55,6 +56,7 @@ function cacheModule(config){
         if(typeof output === 'object'){
           output = cloneObject(output);
         }
+        cache.lastUsed[key] = now;
         cb(null, output);
       }
       else{
@@ -106,8 +108,10 @@ function cacheModule(config){
     if(!self.readOnly){
       try {
         expiration = (expiration) ? (expiration * 1000) : (self.defaultExpiration * 1000);
-        var exp = expiration + Date.now();
+        var now = Date.now();
+        var exp = expiration + now;
         cache.expirations[key] = exp;
+        cache.lastUsed[key] = now;
         cache.db[key] = value;
         if(cb) cb();
         if(refresh){
@@ -157,6 +161,7 @@ function cacheModule(config){
         var key = keys[i];
         delete cache.db[key];
         delete cache.expirations[key];
+        delete cache.lastUsed[key];
         delete cache.refreshKeys[key];
       }
       if(cb) cb(null, keys.length);
@@ -164,6 +169,7 @@ function cacheModule(config){
     else{
       delete cache.db[keys];
       delete cache.expirations[keys];
+      delete cache.lastUsed[keys];
       delete cache.refreshKeys[keys];
       if(cb) cb(null, 1);
     }
@@ -178,11 +184,50 @@ function cacheModule(config){
     log(false, '.flush() called');
     cache.db = {};
     cache.expirations = {};
+    cache.lastUsed = {};
     cache.refreshKeys = {};
     if(cb) cb();
     overwriteBrowserStorage();
     if(interval) clearInterval(interval);
     backgroundRefreshEnabled = false;
+  }
+
+  /**
+   * Flush all expired keys and values
+   * @param {function} cb
+   */
+  self.flushExpired = function(cb){
+    log(false, '.flushExpired() called');
+    var now = Date.now();
+    for(var key in cache.expirations){
+      if(cache.db.hasOwnProperty(key)){
+        var expiration = cache.expirations[key];
+        if(expiration <= now){
+          expire(key);
+        }
+      }
+    }
+    if(cb) cb();
+  }
+
+  /**
+   * Flush keys and values that haven't been used in the last N seconds
+   * (as specified by the timeout).
+   * @param {integer} timeout
+   * @param {function} cb
+   */
+  self.flushUnused = function(timeout, cb){
+    log(false, '.flushUnused() called');
+    var now = Date.now() - (timeout * 1000);
+    for(var key in cache.lastUsed){
+      if(cache.db.hasOwnProperty(key)){
+        var lastUsed = cache.lastUsed[key];
+        if(lastUsed <= now){
+          expire(key);
+        }
+      }
+    }
+    if(cb) cb();
   }
 
   /**
@@ -235,12 +280,14 @@ function cacheModule(config){
   }
 
   /**
-   * Delete a given key from cache.db and cache.expirations but not from cache.refreshKeys
+   * Delete a given key from cache.db, cache.expirations, and cache.lastUsed
+   * but not from cache.refreshKeys
    * @param {string} key
    */
   function expire(key){
     delete cache.db[key];
     delete cache.expirations[key];
+    delete cache.lastUsed[key];
     overwriteBrowserStorage();
   }
 


### PR DESCRIPTION
This adds in two methods:

.flushExpired() which can flush out any keys/values in the cache that have expired. This can make it so that we don't need to wait for them to be accessed before they can be deleted.

.flushUnused(timeout) which can flush out any keys/values that haven't been used in N seconds. This can allow for files to be flushed from the cached on a more aggressive schedule above-and-beyond the normal expiration process.

Test plan:
I ran `npm test` and it passed.